### PR TITLE
build(deps-dev): bump biome to 1.5.0

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.4.1/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.5.0/schema.json",
   "organizeImports": {
     "enabled": true,
     "include": ["src/*.ts", "test/*.ts", "rollup.config.mjs"]

--- a/biome.json
+++ b/biome.json
@@ -25,7 +25,12 @@
         "useEnumInitializers": "warn"
       },
       "nursery": {
-        "noUnusedImports": "warn"
+        "noUnusedImports": "warn",
+        "useExportType": "error",
+        "useImportType": "error",
+        "useNodejsImportProtocol": "error",
+        "noInvalidUseBeforeDeclaration": "error",
+        "noUselessTernary": "error"
       }
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@biomejs/biome": "1.4.1-nightly.e087146",
+        "@biomejs/biome": "^1.5.0",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-replace": "^5.0.5",
         "@rollup/plugin-run": "^3.0.2",
@@ -34,9 +34,9 @@
       "dev": true
     },
     "node_modules/@biomejs/biome": {
-      "version": "1.4.1-nightly.e087146",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.4.1-nightly.e087146.tgz",
-      "integrity": "sha512-fR9cWYue5+cXZ9FwLSfCo5eExRj6RlLstEXt64zKVhZWnrLmotFbGTw4C3fPYENqPq6LT3232rGaMIiOO9iRRw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.5.0.tgz",
+      "integrity": "sha512-ln+o5jbs109qpeDoA+5n+vlAPai3DhlK0tHtZXzQvu4tswFgxNiJCeIXmlW1DYHziTmtBImV3Y0uhbm2iVSE3Q==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -50,20 +50,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "1.4.1-nightly.e087146",
-        "@biomejs/cli-darwin-x64": "1.4.1-nightly.e087146",
-        "@biomejs/cli-linux-arm64": "1.4.1-nightly.e087146",
-        "@biomejs/cli-linux-arm64-musl": "1.4.1-nightly.e087146",
-        "@biomejs/cli-linux-x64": "1.4.1-nightly.e087146",
-        "@biomejs/cli-linux-x64-musl": "1.4.1-nightly.e087146",
-        "@biomejs/cli-win32-arm64": "1.4.1-nightly.e087146",
-        "@biomejs/cli-win32-x64": "1.4.1-nightly.e087146"
+        "@biomejs/cli-darwin-arm64": "1.5.0",
+        "@biomejs/cli-darwin-x64": "1.5.0",
+        "@biomejs/cli-linux-arm64": "1.5.0",
+        "@biomejs/cli-linux-arm64-musl": "1.5.0",
+        "@biomejs/cli-linux-x64": "1.5.0",
+        "@biomejs/cli-linux-x64-musl": "1.5.0",
+        "@biomejs/cli-win32-arm64": "1.5.0",
+        "@biomejs/cli-win32-x64": "1.5.0"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "1.4.1-nightly.e087146",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.4.1-nightly.e087146.tgz",
-      "integrity": "sha512-mDYjCtwF8snkYMkFNiM48DfnpakBwvcUcE3of+YZkXg2E1cesAY2l1wQxnMJeoJnecNlBi0z6bqy0K9uPBywQg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.5.0.tgz",
+      "integrity": "sha512-3+D7axf04dpadGMOaqb2q+zyQnhWW0o/Imt7TJBWsoE0N3/+28Wht8g3UEHHcUL5FPuGIfsE+NcYntBaaAsEIg==",
       "cpu": [
         "arm64"
       ],
@@ -77,9 +77,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "1.4.1-nightly.e087146",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.4.1-nightly.e087146.tgz",
-      "integrity": "sha512-rSMOAJnF2Xwmc/d6FJrRdJmEnI9cPaokeNH913SGfodFqVP0fduP3nRSAmP7G9Hrk+w0hZzKRY9sHo8WUoICUw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.5.0.tgz",
+      "integrity": "sha512-8k5aaLWE/B6ZAXLC+z/Vwh9ogyiSaiRIfvg+F9foxuneHl2R/D/2Iy7pvd3Yoi4Kf6/MBdowekPVezGP4/Kbcw==",
       "cpu": [
         "x64"
       ],
@@ -93,9 +93,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "1.4.1-nightly.e087146",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.4.1-nightly.e087146.tgz",
-      "integrity": "sha512-kIPwiIK+S2qs4cPuTaf2sAo6uPktmolmtDYSWXwlNQr8KnKIRpK62uNxBYpmX0GxDkK64Ww4Cs44QJm7KdbuWg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.5.0.tgz",
+      "integrity": "sha512-RiecxG71E1jnqiJZ3FaikVBDRkk2ohIxBo0O4o68g87y6Hug//G0S83sj6Wqyn8DgKMCRWQg+XYMgk5CwLVowA==",
       "cpu": [
         "arm64"
       ],
@@ -109,9 +109,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "1.4.1-nightly.e087146",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.4.1-nightly.e087146.tgz",
-      "integrity": "sha512-g+s7jSKVl2BCDcNq7qt4cLc53rBqt1QrdoDRvojv+UBSsJmZM0Re72p39vjLzgWAyYYDEiXOXo58KCGe/Lj34w==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.5.0.tgz",
+      "integrity": "sha512-+1B3J8tWLTOvP3+00Cap+XhEXMvxwCHvVfuywUsB7Sqd66NWic3wKJuGbGcS3PuCWtGuIFsiQMNAGqiOXG4uBQ==",
       "cpu": [
         "arm64"
       ],
@@ -125,9 +125,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "1.4.1-nightly.e087146",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.4.1-nightly.e087146.tgz",
-      "integrity": "sha512-TcRcfW0JY8yOf1ghI2mOpw9ttqelP7aKIs6HjV1dNn51taHKclbzYMyxkV9z6SQGXRXhjsaHy9KcYHQdiSuJJA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.5.0.tgz",
+      "integrity": "sha512-TlTsG+ptSmnDTUsAAYsXyGOXMcFiF8SiwhPdj4YsNkJRgx9M2curEVcTVm66FINIPK6VJTUcEDahFlx3NPUOzA==",
       "cpu": [
         "x64"
       ],
@@ -141,9 +141,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "1.4.1-nightly.e087146",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.4.1-nightly.e087146.tgz",
-      "integrity": "sha512-Dayvq7Gd7hahEcfYbonAOMkv5lod4OEVFeN5RwOdz7wTpglLpaFJee/EYZGP7qdgnsxfJe7GR/rxHYw2KnL93w==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.5.0.tgz",
+      "integrity": "sha512-4S2rLluc0WT+XTbLTgcm9+5EEFwJmoGiUEzR6N0P2sIjZD8c5KNf9Ou46BP1Pdg5AgqV+IIClGPK1I80ApSh1Q==",
       "cpu": [
         "x64"
       ],
@@ -157,9 +157,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "1.4.1-nightly.e087146",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.4.1-nightly.e087146.tgz",
-      "integrity": "sha512-J1zuLgwH6KuZ8Db8G2ndY0KWNRo6ax1YvtFKp7f4HP33etpJoMOH8XiZU29nqgvSKob1VZQW3RpvTUzsd6PQfA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.5.0.tgz",
+      "integrity": "sha512-sWOi1SR+YqJuXElBncGRnWBR7IN7ni6GQY4Zm/vTpP6nVA0dX5C301eQUW1N/VnFQb6fyrJTcBslDUKyemsN/g==",
       "cpu": [
         "arm64"
       ],
@@ -173,9 +173,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "1.4.1-nightly.e087146",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.4.1-nightly.e087146.tgz",
-      "integrity": "sha512-rh1JkH2DTRPrRuQOmSDcd/ndY4EflAnG6hgdRLQjss06fEZCcqO/U1nnPu3wdEBPqF+Jqgym7cwn5/+qoyyVrw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.5.0.tgz",
+      "integrity": "sha512-OoqgUXyzmRwX466bklOsWS7WdcvWtBuxF94DXATNe7bUiBa2tlW8QX7VVZvPnMKH57E5J619AkB3b5fhzyUhXA==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Matteo Sacchetto",
   "license": "MIT",
   "devDependencies": {
-    "@biomejs/biome": "1.4.1-nightly.e087146",
+    "@biomejs/biome": "^1.5.0",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-replace": "^5.0.5",
     "@rollup/plugin-run": "^3.0.2",


### PR DESCRIPTION
## Features:
- bump biome to 1.5.0
- enabled the following rules:
  -  useExportType
  - useImportType
  - useNodejsImportProtocol
  - noInvalidUseBeforeDeclaration
  - noUselessTernary